### PR TITLE
Format Sum Types

### DIFF
--- a/aeson-typescript.cabal
+++ b/aeson-typescript.cabal
@@ -59,6 +59,7 @@ test-suite aeson-typescript-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Formatting
       HigherKind
       ObjectWithSingleFieldNoTagSingleConstructors
       ObjectWithSingleFieldTagSingleConstructors
@@ -92,6 +93,7 @@ test-suite aeson-typescript-test
     , interpolate
     , mtl
     , process
+    , strict-base-types
     , template-haskell
     , temporary
     , text

--- a/src/Data/Aeson/TypeScript/Formatting.hs
+++ b/src/Data/Aeson/TypeScript/Formatting.hs
@@ -14,8 +14,18 @@ formatTSDeclarations = formatTSDeclarations' defaultFormattingOptions
 -- | Format a single TypeScript declaration. This version accepts a FormattingOptions object in case you want more control over the output.
 formatTSDeclaration :: FormattingOptions -> TSDeclaration -> String
 formatTSDeclaration (FormattingOptions {..}) (TSTypeAlternatives name genericVariables names) =
-  [i|type #{typeNameModifier name}#{getGenericBrackets genericVariables} = #{alternatives};|]
-  where alternatives = T.intercalate " | " (fmap T.pack names)
+  case sumTypeFormat of
+    Enum -> [i|enum #{typeNameModifier name} { #{alternativesEnum} }|]
+    EnumWithType -> [i|enum #{typeNameModifier name} { #{alternativesEnumWithType} }#{enumType}|]
+    _ -> [i|type #{typeNameModifier name}#{getGenericBrackets genericVariables} = #{alternatives};|]
+  where
+    alternatives = T.intercalate " | " (fmap T.pack names)
+    alternativesEnum = T.intercalate ", " $
+      [T.pack (replicate numIndentSpaces ' ') <> toEnumName entry | entry <- T.pack <$> names]
+    alternativesEnumWithType = T.intercalate ", " $
+      [T.pack (replicate numIndentSpaces ' ') <> toEnumName entry <> "=" <> entry | entry <- T.pack <$> names]
+    enumType = [i|\n\ntype #{name} = keyof typeof #{typeNameModifier name};|]
+    toEnumName = T.replace "\"" ""
 
 formatTSDeclaration (FormattingOptions {..}) (TSInterfaceDeclaration interfaceName genericVariables members) =
   [i|interface #{modifiedInterfaceName}#{getGenericBrackets genericVariables} {
@@ -25,7 +35,21 @@ formatTSDeclaration (FormattingOptions {..}) (TSInterfaceDeclaration interfaceNa
 
 -- | Format a list of TypeScript declarations into a string, suitable for putting directly into a @.d.ts@ file.
 formatTSDeclarations' :: FormattingOptions -> [TSDeclaration] -> String
-formatTSDeclarations' options declarations = T.unpack $ T.intercalate "\n\n" (fmap (T.pack . formatTSDeclaration options) declarations)
+formatTSDeclarations' options declarations = T.unpack $ T.intercalate "\n\n" (fmap (T.pack . formatTSDeclaration (validateFormattingOptions options declarations)) declarations)
+
+validateFormattingOptions :: FormattingOptions -> [TSDeclaration] -> FormattingOptions
+validateFormattingOptions options@FormattingOptions{..} decls
+  | sumTypeFormat == Enum && isPlainSumType decls = options
+  | sumTypeFormat == EnumWithType && isPlainSumType decls = options { typeNameModifier = flip (<>) "Enum" }
+  | otherwise = options { sumTypeFormat = StringLiteralType }
+  where
+    isInterface :: TSDeclaration -> Bool
+    isInterface TSInterfaceDeclaration{} = True
+    isInterface _ = False
+
+    -- Plain sum types have only one declaration with multiple alternatives
+    -- Units (data U = U) contain two declarations, and thus are invalid
+    isPlainSumType ds = (not . any isInterface $ ds) && length ds == 1
 
 formatTSField :: TSField -> String
 formatTSField (TSField optional name typ) = [i|#{name}#{if optional then "?" else ""}: #{typ}|]

--- a/src/Data/Aeson/TypeScript/TH.hs
+++ b/src/Data/Aeson/TypeScript/TH.hs
@@ -111,6 +111,7 @@ module Data.Aeson.TypeScript.TH (
   formatTSDeclarations',
   formatTSDeclaration,
   FormattingOptions(..),
+  SumTypeFormat(..),
 
   -- * Convenience tools
   HasJSONOptions(..),

--- a/src/Data/Aeson/TypeScript/Types.hs
+++ b/src/Data/Aeson/TypeScript/Types.hs
@@ -67,6 +67,11 @@ newtype TSString a = TSString { unpackTSString :: String } deriving Show
 instance IsString (TSString a) where
   fromString = TSString
 
+data SumTypeFormat = StringLiteralType
+                   | Enum
+                   | EnumWithType
+                   deriving (Eq, Show)
+
 -- * Formatting options
 
 data FormattingOptions = FormattingOptions
@@ -76,12 +81,15 @@ data FormattingOptions = FormattingOptions
   -- ^ Function applied to generated interface names
   , typeNameModifier :: String -> String
   -- ^ Function applied to generated type names
+  , sumTypeFormat :: SumTypeFormat
+  -- ^ How to format sum types
   }
 
 defaultFormattingOptions = FormattingOptions
   { numIndentSpaces = 2
   , interfaceNameModifier = id
   , typeNameModifier = id
+  , sumTypeFormat = StringLiteralType
   }
 
 -- | Convenience typeclass class you can use to "attach" a set of Aeson encoding options to a type.

--- a/test/Formatting.hs
+++ b/test/Formatting.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Formatting (tests) where
+
+import Data.Aeson.TypeScript.TH
+import Data.Aeson.TypeScript.Types
+import Data.Aeson.TypeScript.Formatting
+
+import Data.Aeson (defaultOptions)
+import Data.Proxy
+import Test.Hspec
+
+data D = S | F deriving (Eq, Show)
+
+$(deriveTypeScript defaultOptions ''D)
+
+tests :: Spec
+tests = do
+  let stringTypeLiteralType = "type D = \"S\" | \"F\";"
+      enum = "enum D {   S,   F }"
+      enumWithType = "enum DEnum {   S=\"S\",   F=\"F\" }\n\ntype D = keyof typeof DEnum;"
+
+  describe "Formatting" $
+    context "when given a Sum Type" $ do
+      context "and the StringLiteralType format option is set" $
+        it "should generate a TS string literal type" $
+          formatTSDeclarations' defaultFormattingOptions (getTypeScriptDeclarations @D Proxy) `shouldBe` stringTypeLiteralType
+      context "and the Enum format option is set" $
+        it "should generate a TS Enum" $
+          formatTSDeclarations' (defaultFormattingOptions { sumTypeFormat = Enum }) (getTypeScriptDeclarations @D Proxy) `shouldBe` enum
+      context "and the EnumWithType format option is set" $
+        it "should generate a TS Enum with a type declaration" $
+          formatTSDeclarations' (defaultFormattingOptions { sumTypeFormat = EnumWithType }) (getTypeScriptDeclarations @D Proxy) `shouldBe` enumWithType

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -13,6 +13,7 @@ import qualified TwoElemArrayNoTagSingleConstructors
 import qualified TwoElemArrayTagSingleConstructors
 import qualified UntaggedNoTagSingleConstructors
 import qualified UntaggedTagSingleConstructors
+import qualified Formatting
 
 main = hspec $ do
   ObjectWithSingleFieldTagSingleConstructors.tests
@@ -25,3 +26,4 @@ main = hspec $ do
   UntaggedTagSingleConstructors.tests
   UntaggedNoTagSingleConstructors.tests
   HigherKind.tests
+  Formatting.tests


### PR DESCRIPTION
Allow formatting sum types in different fashions.

```haskell
data CountryCode = SG | US | MU deriving (Eq, Show)
```
## String Literal Types
The default and the way it currently works

```typescript
type CountryCode = "SG" | "US" | "MU";
```
## Enum
Create a plain TS enum:

```typescript
enum CountryCode {
    SG,
    US,
    MU,
}
```
## EnumWithType
Creates an enum with a type declaration:

```typescript
enum CountryCodeEnum {
    SG="SG",
    US="US",
    MU="MU"
}

type CountryCode = keyof typeof CountryCodeEnum;
```

This allows us to generate the types from the Enum, which is the intended use in TS, and also allows us to generate collections from the Enum using `Object.keys(CountryCodeEnum)`